### PR TITLE
Add published filter to blog entry list endpoint

### DIFF
--- a/simpleblog/rest_views.py
+++ b/simpleblog/rest_views.py
@@ -10,12 +10,15 @@ from simpleblog.serializers import (
 class CategoryFilter(filters.SearchFilter):
     search_param = "category"
 
+class PublishedFilter(filters.SearchFilter):
+    search_param = 'published'
+
 class EntryListView(ListAPIView):
-    filter_backends = (CategoryFilter,)
+    filter_backends = (CategoryFilter, PublishedFilter,)
     pagination_class = LimitStartPagination
     queryset = Entry.objects.all().order_by('-publication_date')
     serializer_class = EntrySerializer
-    search_fields = ('category__slug', )
+    search_fields = ('category__slug', 'published')
 
 class EntryRetrieveView(RetrieveAPIView):
     queryset = Entry.objects.all().order_by('-publication_date')

--- a/simpleblog/serializers.py
+++ b/simpleblog/serializers.py
@@ -28,7 +28,7 @@ class EntrySerializer(serializers.ModelSerializer):
         fields = (
             'id', 'title', 'slug', 'image', 'intro',
             'publication_date', 'seo_title', 'seo_description',
-            'modified', 'author', 'category', 'url'
+            'modified', 'author', 'category', 'url', 'published',
         )
 
 


### PR DESCRIPTION
We only want to display published blog posts. This PR:
1. adds a filter to the entry list rest endpoint to be able to filter on the `published` field of the `entry` model
2. adds the `published` filter to the api response